### PR TITLE
Update GeoQuery.ts

### DIFF
--- a/src/GeoQuery.ts
+++ b/src/GeoQuery.ts
@@ -402,7 +402,12 @@ export class GeoQuery {
     }
 
     // Keep track of which geohashes have been processed so we know when to fire the 'ready' event
-    this._outstandingGeohashReadyEvents = geohashesToQuery.slice();
+    this._outstandingGeohashReadyEvents = [
+        ...new Set([
+          ...this._outstandingGeohashReadyEvents,
+          ...geohashesToQuery,
+        ]),
+      ];
 
     // Loop through each geohash to query for and listen for new geohashes which have the same prefix.
     // For every match, attach a value callback which will fire the appropriate events.


### PR DESCRIPTION
I implemented this change to address the following problem:

Prerequisites:
Test with no network connectivity

Steps:
1.) Start a location update for a specific location
2.) Follow up with an update criteria call. (This has to happen before step 1, hence the no network connectivity scenario being simulated)

Note that, in reality, there are ~30 geofire keys are to be returned when there is network connectivity.

Actual:
A 'ready' event is falsely fired for the second call, even though the db was not queried yet. The code is ignoring the current queries ongoing for the second call, and thinks that there are no outstanding queries when the second call is invoked because of this line that I replaced:
`this._outstandingGeohashReadyEvents = geohashesToQuery.slice();` 

Expected: (After this change)
The 'ready' event is only fired when all existing queries have been returned.

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
