### PR TITLE
Update GeoQuery.ts

### DIFF
--- a/src/GeoQuery.ts
+++ b/src/GeoQuery.ts
@@ -9,6 +9,7 @@ import { GeoFireTypes } from './GeoFireTypes';
  */
 export class GeoQuery {
   // Event callbacks
+  private _outstandingGeohashReadyEvents = [];
   private _callbacks: GeoFireTypes.QueryCallbacks = { ready: [], key_entered: [], key_exited: [], key_moved: [] };
   // Variable to track when the query is cancelled
   private _cancelled = false;


### PR DESCRIPTION
Prerequisites:
Test with no network connectivity

Steps:
1.) Start a location update for a specific location
2.) Follow up with an update criteria call. (This has to happen before step 1, hence the no network connectivity scenario being simulated)

Note that, in reality, there are ~30 geofire keys are to be returned when there is network connectivity.

Actual:
A 'ready' event is falsely fired for the second call, even though the db was not queried yet. The code is ignoring the current queries ongoing for the second call, and thinks that there are no outstanding queries when the second call is invoked because of this line that I replaced:
this._outstandingGeohashReadyEvents = geohashesToQuery.slice();

Expected: (After this change)
The 'ready' event is only fired when all existing queries have been returned.